### PR TITLE
chore: dependency maintenance 2026-05-21

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,11 @@ vaadin.ts
 frontend/
 vite.*
 *.bundle
+
+## AI tooling
+.claude/
+.claude-flow/
+.swarm/
+.mcp.json
+CLAUDE.md
+ruvector.db

--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,7 @@ pnpm*
 node_modules/
 vaadin.ts
 .npmrc
-frontend/
+src/main/frontend/generated/
 vite.*
 *.bundle
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.0</version>
+		<version>4.0.3</version>
 		<relativePath/>
 		<!-- lookup parent from repository -->
 	</parent>
@@ -72,7 +72,7 @@
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
 		<maven.compiler.proc>full</maven.compiler.proc>
-		<vaadin.version>25.0.0</vaadin.version>
+		<vaadin.version>25.0.7</vaadin.version>
 	</properties>
 
 	<dependencies>
@@ -96,17 +96,17 @@
 		<dependency>
 			<groupId>io.pivotal.cfenv</groupId>
 			<artifactId>java-cfenv</artifactId>
-			<version>3.5.0</version>
+			<version>4.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>io.pivotal.cfenv</groupId>
 			<artifactId>java-cfenv-boot</artifactId>
-			<version>3.5.0</version>
+			<version>4.0.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.cedarsoftware</groupId>
 			<artifactId>json-io</artifactId>
-			<version>4.70.0</version>
+			<version>4.102.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -164,7 +164,7 @@
 		<dependency>
 			<groupId>org.eclipse.jgit</groupId>
 			<artifactId>org.eclipse.jgit</artifactId>
-			<version>7.5.0.202512021534-r</version>
+			<version>7.6.0.202603022253-r</version>
 		</dependency>
 		<dependency>
 			<groupId>com.sanctionco.jmail</groupId>
@@ -174,7 +174,7 @@
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcprov-jdk18on</artifactId>
-			<version>1.83</version>
+			<version>1.84</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -201,7 +201,7 @@
 		<dependency>
 			<groupId>org.codehaus.jettison</groupId>
 			<artifactId>jettison</artifactId>
-			<version>1.5.4</version>
+			<version>1.5.5</version>
 		</dependency>
 		<dependency>
 			<groupId>io.r2dbc</groupId>
@@ -219,7 +219,7 @@
 		<dependency>
 			<groupId>io.github.resilience4j</groupId>
 			<artifactId>resilience4j-annotations</artifactId>
-			<version>2.3.0</version>
+			<version>2.4.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.github.ben-manes.caffeine</groupId>
@@ -270,7 +270,7 @@
 			<dependency>
 				<groupId>tools.jackson</groupId>
 				<artifactId>jackson-bom</artifactId>
-				<version>3.0.3</version>
+				<version>3.1.3</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
@@ -284,7 +284,7 @@
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-dependencies</artifactId>
-				<version>2025.1.0</version>
+				<version>2025.1.1</version>
 				<scope>import</scope>
 				<type>pom</type>
 			</dependency>
@@ -643,6 +643,10 @@
 				<version>4.9.8.2</version>
 				<configuration>
 					<xmlOutput>true</xmlOutput>
+					<excludeFilterFile>src/main/resources/spotbugs-exclude.xml</excludeFilterFile>
+					<effort>Max</effort>
+					<threshold>Low</threshold>
+					<failOnError>true</failOnError>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -691,7 +695,7 @@
 			<plugin>
 				<groupId>com.diffplug.spotless</groupId>
 				<artifactId>spotless-maven-plugin</artifactId>
-				<version>3.1.0</version>
+				<version>3.3.0</version>
 				<configuration>
 					<java>
 						<removeUnusedImports/>

--- a/src/main/frontend/themes/cf-archivist/styles.css
+++ b/src/main/frontend/themes/cf-archivist/styles.css
@@ -1,0 +1,1 @@
+/* Custom theme styles for cf-archivist */

--- a/src/main/frontend/themes/cf-archivist/theme.json
+++ b/src/main/frontend/themes/cf-archivist/theme.json
@@ -1,0 +1,3 @@
+{
+  "variant": "dark"
+}

--- a/src/main/java/org/cftoolsuite/cfapp/CfArchivistApplication.java
+++ b/src/main/java/org/cftoolsuite/cfapp/CfArchivistApplication.java
@@ -8,12 +8,11 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 import com.vaadin.flow.component.page.AppShellConfigurator;
 import com.vaadin.flow.server.PWA;
 import com.vaadin.flow.theme.Theme;
-import com.vaadin.flow.theme.lumo.Lumo;
 
 @EnableScheduling
 @SpringBootApplication
 @ConfigurationPropertiesScan
-@Theme(themeClass = Lumo.class, variant = Lumo.DARK)
+@Theme("cf-archivist")
 @PWA(name = "A dashboard for displaying/filtering time-stamped snapshots over successive pulls from a cf-hoover instance", shortName = "cf-archivist")
 public class CfArchivistApplication implements AppShellConfigurator {
 

--- a/src/main/java/org/cftoolsuite/cfapp/ui/MainLayout.java
+++ b/src/main/java/org/cftoolsuite/cfapp/ui/MainLayout.java
@@ -32,7 +32,7 @@ public class MainLayout extends AppLayout {
     	Tab sidTab = createTab(VaadinIcon.TABLE.create(), "Service Instance", SnapshotServiceInstanceDetailView.class);
 
     	snapshotDetailTabs.add(sadTab, sidTab);
-    	accordion.add("Snapshot Detail", snapshotDetailTabs).addThemeVariants(DetailsVariant.REVERSE);
+    	accordion.add("Snapshot Detail", snapshotDetailTabs).addThemeVariants(DetailsVariant.LUMO_REVERSE);
 
     	addToNavbar(true, homeTab, new DrawerToggle());
     	addToDrawer(accordion);

--- a/src/main/resources/spotbugs-exclude.xml
+++ b/src/main/resources/spotbugs-exclude.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  SpotBugs exclusion filter for Spring Boot applications.
+
+  Template drawn from cf-toolsuite/cf-butler conventions.
+  Copy to: src/main/resources/spotbugs-exclude.xml
+
+  Reference: https://spotbugs.readthedocs.io/en/stable/filter.html
+-->
+<FindBugsFilter
+        xmlns="https://github.com/spotbugs/filter/3.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0
+            https://raw.githubusercontent.com/spotbugs/spotbugs/master/spotbugs/etc/findbugsfilter.xsd">
+
+    <!--
+      EI_EXPOSE_REP2 — "May expose internal representation by incorporating reference
+      to mutable object."
+
+      WHY SUPPRESSED: Spring constructor injection stores collaborators (Services,
+      Repositories, etc.) by reference. This is the correct IoC/DI pattern — making
+      a defensive copy of a Spring-managed bean would break the container's lifecycle
+      management and destroy the singleton guarantee. These are not data-encapsulation
+      objects; they are collaborator references that must remain shared.
+
+      Scope: classes whose names end with common Spring stereotype suffixes.
+      Adjust the class regex to match your project's naming conventions.
+    -->
+    <Match>
+        <Bug pattern="EI_EXPOSE_REP2"/>
+        <Or>
+            <!-- Spring stereotype beans -->
+            <Class name="~.*Service"/>
+            <Class name="~.*ServiceImpl"/>
+            <Class name="~.*Repository"/>
+            <Class name="~.*RepositoryImpl"/>
+            <Class name="~.*Controller"/>
+            <Class name="~.*RestController"/>
+            <Class name="~.*Component"/>
+            <Class name="~.*Configuration"/>
+            <Class name="~.*Config"/>
+            <Class name="~.*Adapter"/>
+            <Class name="~.*Handler"/>
+            <Class name="~.*Processor"/>
+            <Class name="~.*Manager"/>
+            <Class name="~.*Helper"/>
+            <Class name="~.*Client"/>
+            <!-- Domain value objects whose fields are set once at construction -->
+            <Class name="~.*Properties"/>
+            <Class name="~.*Settings"/>
+        </Or>
+    </Match>
+
+    <!--
+      EI_EXPOSE_REP — "May expose internal representation by returning reference
+      to mutable object."
+
+      WHY SUPPRESSED (ApplicationEvent subclasses only): in-process Spring
+      ApplicationEvents are never serialised across a network boundary. The JDK
+      Serializable contract that triggers this warning is inherited from
+      java.util.EventObject, but these events exist only within the same JVM.
+      A defensive copy in the getter would add overhead with no safety benefit.
+    -->
+    <Match>
+        <Bug pattern="EI_EXPOSE_REP"/>
+        <Class name="~.*Event"/>
+    </Match>
+
+    <!--
+      SE_BAD_FIELD — "Non-transient non-serializable instance field in serializable
+      class."
+
+      WHY SUPPRESSED (ApplicationEvent subclasses only): same reasoning as
+      EI_EXPOSE_REP above. The event payload fields (Services, domain objects, etc.)
+      are not serialisable, but the events are never written to an ObjectOutputStream
+      in a correctly-architected Spring application. Marking every field transient
+      would make the events useless.
+    -->
+    <Match>
+        <Bug pattern="SE_BAD_FIELD"/>
+        <Class name="~.*Event"/>
+    </Match>
+
+</FindBugsFilter>


### PR DESCRIPTION
## Dependency Maintenance

Consolidates 10 Dependabot PRs (#256, #265, #266, #267, #268, #271, #273, #274, #275, #276) plus additional stable updates discovered via versions plugin.

### Version Changes

| Artifact | From | To |
|---|---|---|
| \`spring-boot-starter-parent\` | 4.0.0 | 4.0.3 |
| \`vaadin.version\` | 25.0.0 | 25.0.7 |
| \`tools.jackson:jackson-bom\` | 3.0.3 | 3.1.3 |
| \`spring-cloud-dependencies\` | 2025.1.0 | 2025.1.1 |
| \`org.eclipse.jgit:org.eclipse.jgit\` | 7.5.0.202512021534-r | 7.6.0.202603022253-r |
| \`io.pivotal.cfenv:java-cfenv\` | 3.5.0 | 4.0.0 |
| \`io.pivotal.cfenv:java-cfenv-boot\` | 3.5.0 | 4.0.0 |
| \`com.cedarsoftware:json-io\` | 4.70.0 | 4.102.0 |
| \`io.github.resilience4j:resilience4j-annotations\` | 2.3.0 | 2.4.0 |
| \`org.bouncycastle:bcprov-jdk18on\` | 1.83 | 1.84 |
| \`org.codehaus.jettison:jettison\` | 1.5.4 | 1.5.5 |
| \`spotless-maven-plugin\` | 3.1.0 | 3.3.0 |

### SpotBugs Bootstrap

- Added \`src/main/resources/spotbugs-exclude.xml\` suppressing Spring DI false positives (EI_EXPOSE_REP2 on constructor-injected beans, EI_EXPOSE_REP/SE_BAD_FIELD on ApplicationEvent subclasses)
- Enabled \`excludeFilterFile\`, \`effort=Max\`, \`threshold=Low\`, \`failOnError=true\` in plugin config

### Vaadin 25 Deprecation Fixes

- Replaced \`@Theme(themeClass=Lumo.class, variant=Lumo.DARK)\` with \`@Theme("cf-archivist")\` — \`Theme.variant()\` is marked for removal; dark mode preserved via \`src/main/frontend/themes/cf-archivist/theme.json\`
- Replaced \`DetailsVariant.REVERSE\` with \`DetailsVariant.LUMO_REVERSE\` in \`MainLayout\` — \`REVERSE\` is marked for removal in Vaadin 25
- Scoped \`.gitignore\` Vaadin entry from \`frontend/\` to \`src/main/frontend/generated/\` so custom theme files are tracked

### Quality Gates

| Gate | Result |
|---|---|
| \`spotless:apply\` | PASSED |
| \`compile\` | PASSED (no deprecation warnings) |
| \`test\` | PASSED (1/1) |
| \`spotbugs:spotbugs\` | PASSED |

### Follow-on Work

- [ ] **GitHub Actions Node.js migration** — open a separate PR from main: \`actions/checkout@v6\`, \`actions/setup-java@v5\`, \`actions/cache@v5\` (Node 20 retiring June 2, 2026)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)