### PR TITLE
chore: dependency maintenance 2026-05-22

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,10 +46,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Java
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: liberica
         java-version: 25

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,7 +55,7 @@ jobs:
         java-version: 25
 
     - name: Cache local Maven repository
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.m2/repository
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,7 +17,7 @@ jobs:
           distribution: liberica
           java-version: ${{ matrix.java }}
       - name: Cache local Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -10,9 +10,9 @@ jobs:
         java: [ 25 ]
     name: Java ${{ matrix.java }} build
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: liberica
           java-version: ${{ matrix.java }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,9 @@ jobs:
       repository-projects: read
       statuses: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: liberica
           java-version: 25

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.3</version>
+		<version>4.0.6</version>
 		<relativePath/>
 		<!-- lookup parent from repository -->
 	</parent>
@@ -72,7 +72,7 @@
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
 		<maven.compiler.proc>full</maven.compiler.proc>
-		<vaadin.version>25.0.7</vaadin.version>
+		<vaadin.version>25.1.5</vaadin.version>
 	</properties>
 
 	<dependencies>
@@ -314,7 +314,7 @@
 				<plugin>
 					<groupId>org.sonarsource.scanner.maven</groupId>
 					<artifactId>sonar-maven-plugin</artifactId>
-					<version>5.5.0.6356</version>
+					<version>5.6.0.6792</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>
@@ -640,7 +640,7 @@
 			<plugin>
 				<groupId>com.github.spotbugs</groupId>
 				<artifactId>spotbugs-maven-plugin</artifactId>
-				<version>4.9.8.2</version>
+				<version>4.9.8.3</version>
 				<configuration>
 					<xmlOutput>true</xmlOutput>
 					<excludeFilterFile>src/main/resources/spotbugs-exclude.xml</excludeFilterFile>
@@ -695,7 +695,7 @@
 			<plugin>
 				<groupId>com.diffplug.spotless</groupId>
 				<artifactId>spotless-maven-plugin</artifactId>
-				<version>3.3.0</version>
+				<version>3.5.1</version>
 				<configuration>
 					<java>
 						<removeUnusedImports/>
@@ -811,7 +811,7 @@
 				<dependency>
 					<groupId>io.asyncer</groupId>
 					<artifactId>r2dbc-mysql</artifactId>
-					<version>1.4.1</version>
+					<version>1.4.2</version>
 					<scope>runtime</scope>
 				</dependency>
 				<dependency>
@@ -891,7 +891,7 @@
 			<plugin>
 				<groupId>com.github.spotbugs</groupId>
 				<artifactId>spotbugs-maven-plugin</artifactId>
-				<version>4.9.8.2</version>
+				<version>4.9.8.3</version>
 			</plugin>
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
## Dependency Maintenance

### Java / JVM Version Changes

| Artifact | From | To |
|---|---|---|
| spring-boot-starter-parent | 4.0.3 | 4.0.6 |
| vaadin.version | 25.0.7 | 25.1.5 |
| sonar-maven-plugin | 5.5.0.6356 | 5.6.0.6792 |
| spotbugs-maven-plugin | 4.9.8.2 | 4.9.8.3 |
| spotless-maven-plugin | 3.3.0 | 3.5.1 |
| r2dbc-mysql | 1.4.1 | 1.4.2 |

### GitHub Actions Upgrades

| Action | From | To | Files |
|---|---|---|---|
| actions/checkout | v4 | v6 | maven.yml, release.yml, codeql.yml |
| actions/setup-java | v4 | v5 | maven.yml, release.yml, codeql.yml |
| actions/cache | v4 | v5 | maven.yml, codeql.yml |

> **Note**: checkout v4 and setup-java v4 use deprecated Node.js 20. GitHub forces Node.js 24 starting 2026-06-02.

### Quality Gates

| Gate | Result |
|---|---|
| spotless:apply | ✅ PASSED |
| compile | ✅ PASSED |
| test | ✅ PASSED (1/1) |
| spotbugs:spotbugs | ✅ PASSED |

### Consolidated Dependabot PRs

- #282 — bump spring-boot-starter-parent 4.0.3 → 4.0.6
- #283 — bump vaadin.version 25.0.7 → 25.1.5
- #281 — bump sonar-maven-plugin 5.5.0.6356 → 5.6.0.6792
- #284 — bump spotbugs-maven-plugin 4.9.8.2 → 4.9.8.3
- #280 — bump spotless-maven-plugin 3.3.0 → 3.5.1
- #279 — bump r2dbc-mysql 1.4.1 → 1.4.2

🤖 Generated with Claude Code